### PR TITLE
Rename register button

### DIFF
--- a/src/main/resources/templates/fragments/register_fragment.html
+++ b/src/main/resources/templates/fragments/register_fragment.html
@@ -64,7 +64,7 @@
                 <p class="label label-danger" th:errors="*{password}">Incorrect password</p>
             </div>
 
-            <button class="btn btn-lg btn-primary btn-block btn-signin" type="submit">Sign in</button>
+            <button class="btn btn-lg btn-primary btn-block btn-signin" type="submit">Register</button>
         </form>
     </section>
 </th:block>


### PR DESCRIPTION
Button for signing up should not be called Sign In, preferably "Register"?
